### PR TITLE
add required name attribute

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             'chef-shorewall'
 maintainer       'Trond Arve Nordheim'
 maintainer_email 't@binarymarbles.com'
 license          'Apache 2.0'


### PR DESCRIPTION
Starting Chef Client, version 12.8.1
[...]
ERROR: Cookbook loaded at path(s) [~/chef-solo/cookbooks-1/chef-shorewall] has invalid metadata: The `name' attribute is required in cookbook metadata